### PR TITLE
Improve CMake scripts with versioning features

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,8 +1,7 @@
 cmake_minimum_required(VERSION 3.5.1)
 project(sim-eeros)
 
-## Compiler flags
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11")
+set(CMAKE_CXX_STANDARD 14)
 
 find_package(EEROS REQUIRED)
 include_directories(${EEROS_INCLUDE_DIR})

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,6 +5,9 @@ set(CMAKE_CXX_STANDARD 14)
 
 set(RECOMMENDED_EEROS_VERSION 1.0.0.25) # unreleased version which was tested
 
+include(cmake/MunkeiVersionFromGit.cmake)
+version_from_git() # Fetch the library version information from git
+
 include_directories(${ADDITIONAL_INCLUDE_DIRS})
 link_directories(${ADDITIONAL_LINK_DIRS})
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.6)
+cmake_minimum_required(VERSION 3.5.1)
 project(sim-eeros)
 
 ## Compiler flags
@@ -23,3 +23,4 @@ INSTALL(FILES ${CMAKE_CURRENT_SOURCE_DIR}/include/SimDevice.hpp
 	${CMAKE_CURRENT_SOURCE_DIR}/include/AnalogOut.hpp
 	${CMAKE_CURRENT_SOURCE_DIR}/include/Reflect.hpp
 DESTINATION include/sim-eeros)
+

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,12 +3,30 @@ project(sim-eeros)
 
 set(CMAKE_CXX_STANDARD 14)
 
-find_package(EEROS REQUIRED)
-include_directories(${EEROS_INCLUDE_DIR})
-link_directories(${EEROS_LIB_DIR})
+set(RECOMMENDED_EEROS_VERSION 1.0.0.25) # unreleased version which was tested
 
 include_directories(${ADDITIONAL_INCLUDE_DIRS})
 link_directories(${ADDITIONAL_LINK_DIRS})
+
+
+if(NOT DEFINED REQUIRED_EEROS_VERSION OR
+   NOT REQUIRED_EEROS_VERSION MATCHES
+       "^(0|[1-9][0-9]*)[.](0|[1-9][0-9]*)[.](0|[1-9][0-9]*)[.](0|[1-9][0-9]*)$")
+
+  set(REQUIRED_EEROS_VERSION ${RECOMMENDED_EEROS_VERSION})
+  message("Using recommended EEROS version, which is: v${REQUIRED_EEROS_VERSION}")
+
+else()
+  if(NOT ${REQUIRED_EEROS_VERSION} EQUAL ${RECOMMENDED_EEROS_VERSION})
+     message("You are not using the recommended EEROS version, "
+             "which would be: v${RECOMMENDED_EEROS_VERSION}")
+  endif(NOT ${REQUIRED_EEROS_VERSION} EQUAL ${RECOMMENDED_EEROS_VERSION})
+endif()
+
+
+find_package(EEROS ${REQUIRED_EEROS_VERSION} EXACT REQUIRED)
+include_directories(${EEROS_INCLUDE_DIR})
+link_directories(${EEROS_LIB_DIR})
 
 add_subdirectory(lib)
 add_subdirectory(test)

--- a/cmake/MunkeiVersionFromGit.cmake
+++ b/cmake/MunkeiVersionFromGit.cmake
@@ -1,0 +1,179 @@
+# The MIT License (MIT)
+#
+# Copyright (c) 2016-2017 Theo Willows
+#           (c) 2019 A. Kunz - NTB Interstaatliche Hochschule für Technik Buchs Switzerland
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+
+# This file was copied from: https://github.com/Munkei/munkei-cmake
+# Documentation at: https://github.com/Munkei/munkei-cmake/blob/master/doc/MunkeiVersionFromGit.md
+
+
+cmake_minimum_required( VERSION 3.0.0 )
+
+include( CMakeParseArguments )
+
+function( version_from_git )
+  # Parse arguments
+  set( options OPTIONAL FAST )
+  set( oneValueArgs
+    GIT_EXECUTABLE
+    INCLUDE_HASH
+    LOG
+    TIMESTAMP
+    )
+  set( multiValueArgs )
+  cmake_parse_arguments( ARG "${options}" "${oneValueArgs}" "${multiValueArgs}" ${ARGN} )
+
+  # Defaults
+  if( NOT DEFINED ARG_INCLUDE_HASH )
+    set( ARG_INCLUDE_HASH ON )
+  endif()
+
+  if( DEFINED ARG_GIT_EXECUTABLE )
+    set( GIT_EXECUTABLE "${ARG_GIT_EXECUTABLE}" )
+  else ()
+    # Find Git or bail out
+    find_package( Git )
+    if( NOT GIT_FOUND )
+      message( FATAL_ERROR "[MunkeiVersionFromGit] Git not found" )
+    endif( NOT GIT_FOUND )
+  endif()
+
+  # Git describe
+  execute_process(
+    COMMAND           "${GIT_EXECUTABLE}" describe --tags
+    WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}"
+    RESULT_VARIABLE   git_result
+    OUTPUT_VARIABLE   git_describe
+    ERROR_VARIABLE    git_error
+    OUTPUT_STRIP_TRAILING_WHITESPACE
+    ERROR_STRIP_TRAILING_WHITESPACE
+    )
+  if( NOT git_result EQUAL 0 )
+    message( FATAL_ERROR
+      "[MunkeiVersionFromGit] Failed to execute Git: ${git_error}"
+      )
+  endif()
+
+  # Get Git tag
+  execute_process(
+    COMMAND           "${GIT_EXECUTABLE}" describe --tags --abbrev=0
+    WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}"
+    RESULT_VARIABLE   git_result
+    OUTPUT_VARIABLE   git_tag
+    ERROR_VARIABLE    git_error
+    OUTPUT_STRIP_TRAILING_WHITESPACE
+    ERROR_STRIP_TRAILING_WHITESPACE
+    )
+  if( NOT git_result EQUAL 0 )
+    message( FATAL_ERROR
+      "[MunkeiVersionFromGit] Failed to execute Git: ${git_error}"
+      )
+  endif()
+
+  if( git_tag MATCHES "^v(0|[1-9][0-9]*)[.](0|[1-9][0-9]*)[.](0|[1-9][0-9]*)(-[.0-9A-Za-z-]+)?([+][.0-9A-Za-z-]+)?$" )
+    set( version_major "${CMAKE_MATCH_1}" )
+    set( version_minor "${CMAKE_MATCH_2}" )
+    set( version_patch "${CMAKE_MATCH_3}" )
+    set( version_tweak  0                 ) # default if current commit is tagged
+    set( identifiers   "${CMAKE_MATCH_4}" )
+    set( metadata      "${CMAKE_MATCH_5}" )
+  else()
+    message( FATAL_ERROR
+      "[MunkeiVersionFromGit] Git tag isn't valid semantic version: [${git_tag}]"
+      )
+  endif()
+
+  if( "${git_tag}" STREQUAL "${git_describe}" )
+    set( git_at_a_tag ON )
+  endif()
+
+  if( NOT git_at_a_tag )
+    # Extract the Git hash (if one exists)
+    string( REGEX MATCH "g[0-9a-f]+$" git_hash "${git_describe}" )
+    # Extract the number of commits since the last tagged commit and use it as tweak number
+    string( REGEX MATCH "-[1-9][0-9]*-g" version_tweak_raw "${git_describe}" )
+    string( REGEX MATCH "[1-9][0-9]*" version_tweak "${version_tweak_raw}" )
+  endif()
+
+  # Construct the version variables
+  set( version ${version_major}.${version_minor}.${version_patch} )
+  set( semver  ${version} )
+
+  # Identifiers
+  if( identifiers MATCHES ".+" )
+    string( SUBSTRING "${identifiers}" 1 -1 identifiers )
+    set( semver "${semver}-${identifiers}")
+  endif()
+
+  # Metadata
+  # TODO Split and join (add Git hash inbetween)
+  if( metadata MATCHES ".+" )
+    string( SUBSTRING "${metadata}" 1 -1 metadata )
+    # Split
+    string( REPLACE "." ";" metadata "${metadata}" )
+  endif()
+
+  if( NOT git_at_a_tag )
+
+    if( ARG_INCLUDE_HASH )
+      list( APPEND metadata "${git_hash}" )
+    endif( ARG_INCLUDE_HASH )
+
+    # Timestamp
+    if( DEFINED ARG_TIMESTAMP )
+      string( TIMESTAMP timestamp "${ARG_TIMESTAMP}" ${ARG_UTC} )
+      list( APPEND metadata "${timestamp}" )
+    endif( DEFINED ARG_TIMESTAMP )
+
+  endif()
+
+  # Join
+  string( REPLACE ";" "." metadata "${metadata}" )
+
+  if( metadata MATCHES ".+" )
+    set( semver "${semver}+${metadata}")
+  endif()
+
+  # Log the results
+  if( ARG_LOG )
+    message( STATUS
+      "[MunkeiVersionFromGit] Version: ${version}
+     Git tag:     [${git_tag}]
+     Git hash:    [${git_hash}]
+     Decorated:   [${git_describe}]
+     Identifiers: [${identifiers}]
+     Metadata:    [${metadata}]
+     SemVer:      [${semver}]"
+      )
+  endif( ARG_LOG )
+
+  # Set parent scope variables
+  set( GIT_TAG       ${git_tag}       PARENT_SCOPE )
+  set( SEMVER        ${semver}        PARENT_SCOPE )
+  set( VERSION       ${version}       PARENT_SCOPE )
+  set( VERSION_MAJOR ${version_major} PARENT_SCOPE )
+  set( VERSION_MINOR ${version_minor} PARENT_SCOPE )
+  set( VERSION_PATCH ${version_patch} PARENT_SCOPE )
+  set( VERSION_TWEAK ${version_tweak} PARENT_SCOPE )
+
+endfunction( version_from_git )
+

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -5,7 +5,12 @@ set(SIMEEROS_SRCS SimDevice.cpp DigIn.cpp DigOut.cpp AnalogIn.cpp AnalogOut.cpp)
 add_library(simeeros SHARED ${SIMEEROS_SRCS})
 add_library(simeeros_static ${SIMEEROS_SRCS})
 
+
+set(LIBRARY_VERSION ${VERSION_MAJOR}.${VERSION_MINOR}.${VERSION_PATCH}.${VERSION_TWEAK})
 target_link_libraries(simeeros eeros)
+set_target_properties(simeeros PROPERTIES VERSION ${LIBRARY_VERSION})
+
 target_link_libraries(simeeros_static eeros)
 
-INSTALL(FILES ${CMAKE_CURRENT_BINARY_DIR}/libsimeeros.so ${CMAKE_CURRENT_BINARY_DIR}/libsimeeros_static.a DESTINATION lib)
+INSTALL(TARGETS simeeros simeeros_static LIBRARY DESTINATION lib ARCHIVE DESTINATION lib)
+


### PR DESCRIPTION
# Features
* CMake checks required EEROS version
* Library version is fetched from the last git tag
* Version property is set on the shared library

# Notes
* The recommended EEROS version is set to v1.0.0.25 since this unreleased version was tested.
* No released version (for example Release v1.0.0) is running until now.